### PR TITLE
feat: 예외 처리 및 티켓 순서 변경 기능 추가

### DIFF
--- a/src/controllers/board.controller.ts
+++ b/src/controllers/board.controller.ts
@@ -6,6 +6,8 @@ import { TeamMemberGuard } from './guards/team-member.guard';
 import { UpdateColumnOrderDto } from './dtos/update-column-order.dto';
 import { CreateTicketDto } from './dtos/create-ticket.dto';
 import { ParseColumnIdPipe } from './pipes/parse-column-id.pipe';
+import { ParseTicketIdPipe } from './pipes/parse.ticket-id.pipe';
+import { UpdateTicketOrderDto } from './dtos/update-ticket-order.dto';
 
 @Controller('board')
 export class BoardController {
@@ -34,6 +36,17 @@ export class BoardController {
 		const { column, toBe } = dto;
 
 		return await this.boardService.changeColumnOrder(column, toBe, teamId);
+	}
+
+	@Patch('/:teamId/ticket/order')
+	@UseGuards(AtGuard, TeamMemberGuard)
+	async changeTicketOrder(
+		@Param('teamId', ParseIntPipe) teamId: number,
+		@Body(ParseTicketIdPipe) dto: UpdateTicketOrderDto,
+	) {
+		const { ticket, toBe, toBeColumnId } = dto;
+
+		return await this.boardService.changeTicketOrder(ticket, toBe, toBeColumnId);
 	}
 
 	@Post('/:teamId/ticket')

--- a/src/controllers/dtos/update-ticket-order.dto.ts
+++ b/src/controllers/dtos/update-ticket-order.dto.ts
@@ -1,0 +1,21 @@
+import { Ticket } from '@prisma/client';
+import { Exclude } from 'class-transformer';
+import { IsNotEmpty, IsNumber, IsOptional } from 'class-validator';
+
+export class UpdateTicketOrderDto {
+	@IsNumber()
+	@IsNotEmpty()
+	ticketId: number;
+
+	@IsNumber()
+	@IsNotEmpty()
+	toBe: number;
+
+	@IsOptional()
+	@IsNotEmpty()
+	@IsNumber()
+	toBeColumnId: number;
+
+	@Exclude()
+	ticket: Ticket;
+}

--- a/src/controllers/pipes/parse-column-id.pipe.ts
+++ b/src/controllers/pipes/parse-column-id.pipe.ts
@@ -1,11 +1,12 @@
 import { PipeTransform, Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from 'src/services/prisma.service';
+import { UpdateColumnOrderDto } from '../dtos/update-column-order.dto';
 
 @Injectable()
 export class ParseColumnIdPipe implements PipeTransform {
 	constructor(private readonly prisma: PrismaService) {}
 
-	async transform(value: any) {
+	async transform(value: UpdateColumnOrderDto) {
 		const { columnId } = value;
 		const column = await this.findColumn(columnId);
 

--- a/src/controllers/pipes/parse.ticket-id.pipe.ts
+++ b/src/controllers/pipes/parse.ticket-id.pipe.ts
@@ -1,0 +1,29 @@
+import { Injectable, NotFoundException, PipeTransform } from '@nestjs/common';
+import { PrismaService } from 'src/services/prisma.service';
+import { UpdateTicketOrderDto } from '../dtos/update-ticket-order.dto';
+
+@Injectable()
+export class ParseTicketIdPipe implements PipeTransform {
+	constructor(private readonly prisma: PrismaService) {}
+
+	async transform(value: UpdateTicketOrderDto) {
+		const { ticketId } = value;
+		const ticket = await this.findTicket(ticketId);
+
+		return { ...value, ticket };
+	}
+
+	async findTicket(ticketId: number) {
+		const ticket = await this.prisma.ticket.findUnique({
+			where: {
+				id: ticketId,
+			},
+		});
+
+		if (!ticket) {
+			throw new NotFoundException('존재하지 않는 티켓입니다.');
+		}
+
+		return ticket;
+	}
+}


### PR DESCRIPTION
- 초대시, 존재하지 않는 유저 유무 체크와 이미 초대한 유저인지 체크하여 예외처리
- 초대 수락시, 유저 존재 유무와 이미 수락한 초대인지 체크하여 예외 처리

- 다른 컬럼에 티켓 이동의 경우

컬럼 A, B, C
티켓 1, 2, 3
컬럼 A에 티켓 1, 2, 3이 존재하고 정렬 순서는 1, 2, 3 숫자로 이루어짐
컬럼 B에 티켓 1을 옮기면 컬럼 A의 순서가 재정렬되어서 2, 3이 1, 2 로 변경

- 같은 컬럼 내에서의 순서 변경의 경우

컬럼 A에서 티켓 1, 2, 3이 존재하는데 이 때 티켓 3을 티켓 1의 앞에 정렬함
이 때 티켓 1, 2의 순서는 증가하고 티켓 3의 순서는 감소함 (0이나 음수가 될 수 없음)

- 다른 컬럼에 티켓을 옮기는데, 해당 컬럼에 이미 티켓들이 존재하는 경우

컬럼 A의 티켓 1이 존재, 컬럼 B에 티켓 2, 3이 존재
컬럼 A의 티켓을 컬럼 B 티켓 2의 앞쪽에 배치해서 컬럼 B의 정렬 순서가 티켓 1, 2, 3

- toBe가 0보다 낮은경우 toBe는 최소값인 1이 됩니다.
- parseTicketIdPipe 입력값으로 들어오는 ticket id가 존재하는지 검증하고, Ticket 객체로 변환하여 반환합니다. 서비스에서 개발시에는 컨트롤러에서 들어온 Ticket 객체를 활용하여 개발합니다.

- 티켓 순서보장을 위해 toBe는 티켓 총 갯수에 1을 더한 숫자를 넘을 수 없도록 예외 처리

이 부분은 클라이언트 측(여기서는 프론트엔드)에서 잘못된 데이터가 입력될 경우를 대비해 처리했습니다.

feat-#45