### PR TITLE
fix: 티켓 순서 변경 API 예외처리

### DIFF
--- a/src/controllers/pipes/parse-column-id.pipe.ts
+++ b/src/controllers/pipes/parse-column-id.pipe.ts
@@ -21,7 +21,7 @@ export class ParseColumnIdPipe implements PipeTransform {
 		});
 
 		if (!column) {
-			throw new NotFoundException('존재하지 않는 컬럼 ID입니다.');
+			throw new NotFoundException('존재하지 않는 컬럼입니다.');
 		}
 
 		return column;


### PR DESCRIPTION
티켓이 동일한 팀의 컬럼 내에서 이동되는지의 여부를 체크
현재 팀 내에 존재하지 않는 컬럼이나 다른 팀의 컬럼으로 이동되는 경우를 예외처리

fix-#47