### PR TITLE
feat: 컬럼 API 기능 추가

### DIFF
--- a/src/controllers/board.controller.ts
+++ b/src/controllers/board.controller.ts
@@ -8,6 +8,10 @@ import { CreateTicketDto } from './dtos/create-ticket.dto';
 import { ParseColumnIdPipe } from './pipes/parse-column-id.pipe';
 import { ParseTicketIdPipe } from './pipes/parse.ticket-id.pipe';
 import { UpdateTicketOrderDto } from './dtos/update-ticket-order.dto';
+import { UpdateColumnDto } from './dtos/update-column.dto';
+import { TeamLeaderGuard } from './guards/team-leader.guard';
+import { DeleteColumnDto } from './dtos/delete-column.dto';
+import { ColumnWithTickets } from 'src/utils/column-with-tickets.type';
 
 @Controller('board')
 export class BoardController {
@@ -36,6 +40,22 @@ export class BoardController {
 		const { column, toBe } = dto;
 
 		return await this.boardService.changeColumnOrder(column, toBe, teamId);
+	}
+
+	@Patch('/:teamId/column')
+	@UseGuards(AtGuard, TeamMemberGuard)
+	async updateColumn(@Body(ParseColumnIdPipe) dto: UpdateColumnDto) {
+		const { column, name } = dto;
+
+		return await this.boardService.updateColumn(column, name);
+	}
+
+	@Delete('/:teamId/column')
+	@UseGuards(AtGuard, TeamLeaderGuard)
+	async deleteColumn(@Body(ParseColumnIdPipe) dto: DeleteColumnDto) {
+		const column = dto.column as ColumnWithTickets;
+
+		return await this.boardService.deleteColumn(column);
 	}
 
 	@Patch('/:teamId/ticket/order')

--- a/src/controllers/dtos/delete-column.dto.ts
+++ b/src/controllers/dtos/delete-column.dto.ts
@@ -1,0 +1,4 @@
+import { PickType } from '@nestjs/mapped-types';
+import { UpdateColumnDto } from './update-column.dto';
+
+export class DeleteColumnDto extends PickType(UpdateColumnDto, ['columnId', 'column']) {}

--- a/src/controllers/dtos/update-column.dto.ts
+++ b/src/controllers/dtos/update-column.dto.ts
@@ -1,0 +1,16 @@
+import { Column } from '@prisma/client';
+import { Exclude } from 'class-transformer';
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+
+export class UpdateColumnDto {
+	@IsString()
+	@IsNotEmpty()
+	name: string;
+
+	@IsNumber()
+	@IsNotEmpty()
+	columnId: number;
+
+	@Exclude()
+	column: Column;
+}

--- a/src/controllers/pipes/parse-column-id.pipe.ts
+++ b/src/controllers/pipes/parse-column-id.pipe.ts
@@ -1,12 +1,11 @@
 import { PipeTransform, Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from 'src/services/prisma.service';
-import { UpdateColumnOrderDto } from '../dtos/update-column-order.dto';
 
 @Injectable()
 export class ParseColumnIdPipe implements PipeTransform {
 	constructor(private readonly prisma: PrismaService) {}
 
-	async transform(value: UpdateColumnOrderDto) {
+	async transform(value: any) {
 		const { columnId } = value;
 		const column = await this.findColumn(columnId);
 
@@ -17,6 +16,9 @@ export class ParseColumnIdPipe implements PipeTransform {
 		const column = await this.prisma.column.findUnique({
 			where: {
 				id: columnId,
+			},
+			include: {
+				tickets: true,
 			},
 		});
 

--- a/src/filters/prisma-exception.filter.ts
+++ b/src/filters/prisma-exception.filter.ts
@@ -1,0 +1,24 @@
+import { ArgumentsHost, Catch, Logger, ExceptionFilter } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { Request, Response } from 'express';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
+
+@Catch(PrismaClientKnownRequestError)
+export class PrismaExceptionFilter implements ExceptionFilter {
+	constructor(private readonly logger: Logger) {}
+
+	catch(exception: Prisma.PrismaClientKnownRequestError, host: ArgumentsHost) {
+		const ctx = host.switchToHttp();
+		const response = ctx.getResponse<Response>();
+		const request = ctx.getRequest<Request>();
+		const message = exception.meta.cause;
+		const prismaCode = exception.code;
+
+		response.status(400).json({
+			message,
+			errorCode: prismaCode,
+			timestamp: new Date().toISOString(),
+			path: request.url,
+		});
+	}
+}

--- a/src/modules/provide.module.ts
+++ b/src/modules/provide.module.ts
@@ -2,6 +2,7 @@ import { Logger, Module, ValidationPipe } from '@nestjs/common';
 import { APP_FILTER, APP_INTERCEPTOR, APP_PIPE } from '@nestjs/core';
 import { TransformInterceptor } from 'src/controllers/interceptors/transform.interceptor';
 import { HttpExceptionFilter } from 'src/filters/http-exception.filter';
+import { PrismaExceptionFilter } from 'src/filters/prisma-exception.filter';
 import { ValidationExceptionFilter } from 'src/filters/validation-exception.filter';
 import { validationExceptionFactory } from 'src/utils/validation-exception.factory';
 
@@ -23,6 +24,10 @@ import { validationExceptionFactory } from 'src/utils/validation-exception.facto
 		{
 			provide: APP_FILTER,
 			useClass: HttpExceptionFilter,
+		},
+		{
+			provide: APP_FILTER,
+			useClass: PrismaExceptionFilter,
 		},
 		{
 			provide: APP_FILTER,

--- a/src/services/board.service.ts
+++ b/src/services/board.service.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Injectable, UnprocessableEntityException } from '@nestjs/common';
 import { PrismaService } from './prisma.service';
 import { Column, Tag, Ticket } from '@prisma/client';
+import { ColumnWithTickets } from 'src/utils/column-with-tickets.type';
 
 @Injectable()
 export class BoardService {
@@ -135,6 +136,41 @@ export class BoardService {
 						dueDate: true,
 					},
 				},
+			},
+		});
+	}
+
+	async deleteColumn(column: ColumnWithTickets) {
+		if (column.tickets.length) {
+			throw new BadRequestException('하위 티켓이 존재하지 않는 컬럼만 삭제할 수 있습니다.');
+		}
+
+		return await this.prisma.column.delete({
+			select: {
+				id: true,
+				name: true,
+			},
+			where: {
+				id: column.id,
+			},
+		});
+	}
+
+	async updateColumn(column: Column, name: string) {
+		if (column.name == name) {
+			return;
+		}
+
+		return await this.prisma.column.update({
+			select: {
+				name: true,
+				id: true,
+			},
+			where: {
+				id: column.id,
+			},
+			data: {
+				name,
 			},
 		});
 	}

--- a/src/utils/column-with-tickets.type.ts
+++ b/src/utils/column-with-tickets.type.ts
@@ -1,0 +1,7 @@
+import { Prisma } from '@prisma/client';
+
+export type ColumnWithTickets = Prisma.ColumnGetPayload<{
+	include: {
+		tickets: true;
+	};
+}>;


### PR DESCRIPTION
### 컬럼 수정 API
- 현재는 딱히 수정할 내용이 없어서, 이름만 변경할 수 있도록 구현함

### 컬럼 삭제 API
- 컬럼 하위 티켓이 존재하지 않아야 삭제 할 수 있도록 구현
- 컬럼 ID 파싱 파이프에서 컬럼 객체로 변환할 때, 티켓까지 포함하도록 구현함
- 컬럼과 티켓이 포함된 타입을 구현함

feat-#52