### PR TITLE
feat: 티켓 수정 API

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,13 +66,13 @@ model Ticket {
 }
 
 model TicketInfo {
-  id        Int       @id @default(autoincrement())
+  id        Int      @id @default(autoincrement())
   title     String
   tag       Tag
   dueTime   Float?
-  dueDate   DateTime?
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @updatedAt
+  dueDate   String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
   ticket    Ticket[]
 }
 

--- a/src/controllers/board.controller.ts
+++ b/src/controllers/board.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Param, ParseIntPipe, Post, UseGuards, Get, Patch, Delete } from '@nestjs/common';
+import { Body, Controller, Param, ParseIntPipe, Post, UseGuards, Get, Patch, Delete, Put } from '@nestjs/common';
 import { CreateColumnDto } from './dtos/create-column.dto';
 import { AtGuard } from './guards/at.guard';
 import { BoardService } from 'src/services/board.service';
@@ -12,6 +12,7 @@ import { UpdateColumnDto } from './dtos/update-column.dto';
 import { TeamLeaderGuard } from './guards/team-leader.guard';
 import { DeleteColumnDto } from './dtos/delete-column.dto';
 import { ColumnWithTickets } from 'src/utils/column-with-tickets.type';
+import { UpdateTicketDto } from './dtos/update-ticket.dto';
 
 @Controller('board')
 export class BoardController {
@@ -75,6 +76,12 @@ export class BoardController {
 		const { column, title, tag } = dto;
 
 		return await this.boardService.createTicket(column, title, tag);
+	}
+
+	@Put('/:teamId/ticket')
+	@UseGuards(AtGuard, TeamMemberGuard)
+	async updateTicket(@Body(ParseTicketIdPipe) dto: UpdateTicketDto) {
+		return await this.boardService.updateTicket(dto);
 	}
 
 	@Delete('/:teamId/:ticketId')

--- a/src/controllers/dtos/update-ticket.dto.ts
+++ b/src/controllers/dtos/update-ticket.dto.ts
@@ -1,0 +1,34 @@
+import { Tag, Ticket } from '@prisma/client';
+import { Exclude } from 'class-transformer';
+import { IsDateString, IsEnum, IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class UpdateTicketDto {
+	@IsOptional()
+	@IsNumber()
+	assigneeId?: number;
+
+	@IsNumber()
+	@IsNotEmpty()
+	ticketId: number;
+
+	@IsOptional()
+	@IsString()
+	title?: string;
+
+	@IsOptional()
+	@IsEnum(Tag)
+	tag: Tag;
+
+	@IsOptional()
+	@IsDateString({
+		strictSeparator: true,
+	})
+	dueDate: string;
+
+	@IsOptional()
+	@IsNumber()
+	dueTime: number;
+
+	@Exclude()
+	ticket: Ticket;
+}

--- a/src/services/board.service.ts
+++ b/src/services/board.service.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Injectable, UnprocessableEntityException } from '@
 import { PrismaService } from './prisma.service';
 import { Column, Tag, Ticket } from '@prisma/client';
 import { ColumnWithTickets } from 'src/utils/column-with-tickets.type';
+import { UpdateTicketDto } from 'src/controllers/dtos/update-ticket.dto';
 
 @Injectable()
 export class BoardService {
@@ -38,7 +39,12 @@ export class BoardService {
 							select: {
 								id: true,
 								order: true,
-								assignee: true,
+								assignee: {
+									select: {
+										id: true,
+										username: true,
+									},
+								},
 								info: true,
 							},
 							orderBy: {
@@ -134,6 +140,31 @@ export class BoardService {
 						tag: true,
 						dueTime: true,
 						dueDate: true,
+					},
+				},
+			},
+		});
+	}
+
+	async updateTicket(dto: UpdateTicketDto) {
+		await this.prisma.ticket.update({
+			where: {
+				id: dto.ticket.id,
+			},
+			data: {
+				assignee: {
+					connect: {
+						id: dto.assigneeId,
+					},
+				},
+				info: {
+					update: {
+						data: {
+							title: dto.title,
+							dueDate: dto.dueDate,
+							dueTime: dto.dueTime,
+							tag: dto.tag,
+						},
 					},
 				},
 			},


### PR DESCRIPTION
### 티켓 수정 API
티켓을 생성한 후에 티켓에 담당자를 배정 할 수 있습니다.
- 담당자 배정 기능
- 마감 날짜 설정
  - ISO 8601 형식의 문자열만 받으며, 시간을 포함하지 않은 "날짜"만 입력값으로 받습니다.
- 작업 시간 설정
- 제목 변경

feat-#54